### PR TITLE
feat: Producer metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ As a result, at runtime - only the  bytecode is being executed, without any init
 
 As a dynamic language with quirks, JavaScript cannot be compiled directly into bytecode without including a comprehensive ECMA-262 spec-compliant runtime engine. Componentization of JavaScript thus involves embedding the JS runtime engine into the component itself.
 
-SpiderMonkey is chosen here as a the only JS engine with first-class WASI build support. The total embedding size is around 5MB.
+SpiderMonkey is chosen here as a JS engine with first-class WASI build support. The total embedding size is around 5MB.
 
-One of the benefits of the component model is complete code isolation apart from the shared-nothing code boundaries between components. By fully encapsulating
+One of the security benefits of the component model is complete code isolation apart from the shared-nothing code boundaries between components. By fully encapsulating
 the engine embedding for each individual component, this maintains comprehensive per-component isolation.
 
 As more components are written in JavaScript, and there exist scenarios where multiple JS components are communicating in the same application, the plan for optimization here is to share the SpiderMonkey engine embedding between them. This can be done without breaking the shared-nothing semantics by having the engine itself loaded as a shared library of the components. Sharing functions via same SpiderMonkey build, not memory.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,14 @@
 {
   "name": "@bytecodealliance/componentize-js",
+  "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bytecodealliance/componentize-js",
+      "version": "0.0.1",
       "dependencies": {
-        "@bytecodealliance/jco": "^0.4.0",
+        "@bytecodealliance/jco": "^0.4.1",
         "@jakechampion/wizer": "^1.6.0"
       },
       "devDependencies": {
@@ -15,9 +17,9 @@
       }
     },
     "node_modules/@bytecodealliance/jco": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@bytecodealliance/jco/-/jco-0.4.0.tgz",
-      "integrity": "sha512-WDvBCxLODwK/2YmvaHsZKCYnKlFanA4jAJQLQ7/vu05Qe3AkScSIi2qj8RGYL/cY6BZ+KCCqudDrvALMnWW9/g==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/jco/-/jco-0.4.1.tgz",
+      "integrity": "sha512-fb7QID6CtJhBO2jj71/VqBVphPcxWi72uIZnwCHDobgiq+8TM4XFuJEYFD7OOd8u19HlXGrtTujgFPXErx4JwA==",
       "bin": {
         "jco": "cli.mjs"
       }
@@ -1008,9 +1010,9 @@
   },
   "dependencies": {
     "@bytecodealliance/jco": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@bytecodealliance/jco/-/jco-0.4.0.tgz",
-      "integrity": "sha512-WDvBCxLODwK/2YmvaHsZKCYnKlFanA4jAJQLQ7/vu05Qe3AkScSIi2qj8RGYL/cY6BZ+KCCqudDrvALMnWW9/g=="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@bytecodealliance/jco/-/jco-0.4.1.tgz",
+      "integrity": "sha512-fb7QID6CtJhBO2jj71/VqBVphPcxWi72uIZnwCHDobgiq+8TM4XFuJEYFD7OOd8u19HlXGrtTujgFPXErx4JwA=="
     },
     "@bytecodealliance/preview2-shim": {
       "version": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "mocha": "^10.2.0"
   },
   "dependencies": {
-    "@bytecodealliance/jco": "^0.4.0",
+    "@bytecodealliance/jco": "^0.4.1",
     "@jakechampion/wizer": "^1.6.0"
   },
   "scripts": {

--- a/src/componentize.js
+++ b/src/componentize.js
@@ -1,11 +1,12 @@
 import wizer from "@jakechampion/wizer";
-import { componentNew } from "@bytecodealliance/jco";
+import { componentNew, metadataAdd } from "@bytecodealliance/jco";
 import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { readFile, unlink, writeFile } from "node:fs/promises";
 import { exports } from "../lib/spidermonkey-embedding-splicer.js";
 import { fileURLToPath } from "node:url";
+const { version } = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'));
 
 const { spliceBindings } = exports;
 
@@ -282,9 +283,12 @@ export async function componentize(
     process.exit(1);
   }
 
-  const component = componentNew(bin, [
-    ["wasi_snapshot_preview1", await readFile(preview2Adapter)],
-  ]);
+  const component = await metadataAdd(await componentNew(bin, Object.entries({
+    wasi_snapshot_preview1: await readFile(preview2Adapter)
+  })), Object.entries({
+    language: [['JavaScript', '']],
+    'processed-by': [['ComponentizeJS', version]],
+  }));
 
   return {
     component,


### PR DESCRIPTION
Adds `JavaScript` and the `ComponentizeJS` strings to the producer metadata section of the output component.

Resolves https://github.com/bytecodealliance/componentize-js/issues/2.