### PR TITLE
chore: add repo as homepage to package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bytecodealliance/componentize-js",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bytecodealliance/componentize-js",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "dependencies": {
         "@bytecodealliance/jco": "^0.5.5",
         "@bytecodealliance/wizer": "^1.6.1-beta.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@bytecodealliance/componentize-js",
   "version": "0.0.5",
+  "homepage": "https://github.com/bytecodealliance/componentize-js#readme",
   "type": "module",
   "exports": "./src/componentize.js",
   "devDependencies": {


### PR DESCRIPTION
This PR adds the GitHub repository as a temporary (?) `homepage` to `package.json` -- enabling `componentize-js` to have a link to the repo be shown on NPM.

Note that `package-lock.json` wasn't updated yet after the new version so that got pulled in too after `npm install`