### PR TITLE
Update EXAMPLE.md to fix spelling issues & add a couple of steps

### DIFF
--- a/EXAMPLE.md
+++ b/EXAMPLE.md
@@ -162,7 +162,7 @@ Building and running the binary should print the result:
 ```
 cargo build --release
 ./target/release/wasmtime-test
-> Hello CompontizeJS
+> Hello ComponentizeJS
 ```
 
 ### Running the Component in Node.js
@@ -186,6 +186,21 @@ We can install this shim itself from npm as well:
 ```
 npm install @bytecodealliance/preview2-shim
 ```
+
+Create package.json in the *hello* folder
+
+```npm init
+```
+
+Append the below line to the package.json file that was just created.
+
+```
+"type": "module",
+```
+
+This is added to ensure all .js and .mjs files are interpreted as ES modules. 
+
+In the absence of this, you may receive the following error SyntaxError: Cannot use import statement outside a module
 
 To test the component:
 


### PR DESCRIPTION
I tried running the wasm component in a node environment & I received the following error without the addition of the package.json file in the *hello* folder.

```
import { getStdio as lowering10Callee, getDirectories as lowering11Callee } from '@bytecodealliance/preview2-shim/preopens';
^^^^^^

SyntaxError: Cannot use import statement outside a module
    at Object.compileFunction (node:vm:360:18)
    at wrapSafe (node:internal/modules/cjs/loader:1055:15)
    at Module._compile (node:internal/modules/cjs/loader:1090:27)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1180:10)
    at Module.load (node:internal/modules/cjs/loader:1004:32)
    at Function.Module._load (node:internal/modules/cjs/loader:839:12)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/translators:170:29)
    at ModuleJob.run (node:internal/modules/esm/module_job:193:25)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:533:24)
```