### PR TITLE
WASI Stubs

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,18 +292,18 @@ checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.180"
+version = "1.0.181"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea67f183f058fe88a4e3ec6e2788e003840893b91bac4559cabedd00863b3ed"
+checksum = "6d3e73c93c3240c0bda063c239298e633114c69a888c3e37ca8bb33f343e9890"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.180"
+version = "1.0.181"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24e744d7782b686ab3b73267ef05697159cc0e5abbed3f47f9933165e5219036"
+checksum = "be02f6cb0cd3a5ec20bbcfbcbd749f57daddb1a0882dc2e46a6c236c90b977ed"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ await writeFile('test.component.wasm', component);
 
 The component iself can be executed in any component runtime, see the [example](EXAMPLE.md) for a full workflow.
 
+## Console Support
+
+By default, `console.log` calls will not write to `stdout`, unless explicitly configured by the `enableStdout: true` option.
+
+In future this will use the WASI logging subsystem directly.
+
 ## API
 
 ```js
@@ -96,7 +102,8 @@ componentize(jsSource: string, {
   debug?: bool,
   sourceName?: string,
   engine?: string,
-  preview2Adapter?: string
+  preview2Adapter?: string,
+  enableStdout?: bool,
 }): {
   component: Uint8Array,
   imports: string[]

--- a/crates/spidermonkey-embedding-splicer/src/lib.rs
+++ b/crates/spidermonkey-embedding-splicer/src/lib.rs
@@ -4,6 +4,9 @@ use std::path::{Path, PathBuf};
 
 mod bindgen;
 mod splice;
+mod stub_wasi;
+
+use crate::stub_wasi::stub_wasi;
 
 use wasm_encoder::{Encode, Section};
 use wit_component::StringEncoding;
@@ -91,6 +94,10 @@ fn parse_wit(path: &Path) -> Result<(Resolve, PackageId)> {
 }
 
 impl SpidermonkeyEmbeddingSplicer for SpidermonkeyEmbeddingSplicerComponent {
+    fn stub_wasi(wasm: Vec<u8>) -> Result<Vec<u8>, String> {
+        stub_wasi(wasm).map_err(|e| e.to_string())
+    }
+
     fn splice_bindings(
         source_name: Option<String>,
         engine: Vec<u8>,

--- a/crates/spidermonkey-embedding-splicer/src/lib.rs
+++ b/crates/spidermonkey-embedding-splicer/src/lib.rs
@@ -94,8 +94,8 @@ fn parse_wit(path: &Path) -> Result<(Resolve, PackageId)> {
 }
 
 impl SpidermonkeyEmbeddingSplicer for SpidermonkeyEmbeddingSplicerComponent {
-    fn stub_wasi(wasm: Vec<u8>) -> Result<Vec<u8>, String> {
-        stub_wasi(wasm).map_err(|e| e.to_string())
+    fn stub_wasi(wasm: Vec<u8>, stdout: bool) -> Result<Vec<u8>, String> {
+        stub_wasi(wasm, stdout).map_err(|e| e.to_string())
     }
 
     fn splice_bindings(

--- a/crates/spidermonkey-embedding-splicer/src/splice.rs
+++ b/crates/spidermonkey-embedding-splicer/src/splice.rs
@@ -50,35 +50,6 @@ pub fn splice(
     // create the exported functions as wrappers around the "cabi_call" function
     synthesize_export_functions(&mut module, &exports)?;
 
-    // stub out the unneeded wasi imports
-    let mut to_stub = Vec::new();
-    for impt in module.imports.iter_mut() {
-        if impt.module == "wasi_snapshot_preview1" {
-            if impt.name != "clock_time_get" && impt.name != "random_get" {
-                let fid = match impt.kind {
-                    walrus::ImportKind::Function(fid) => fid,
-                    _ => panic!(),
-                };
-                to_stub.push((fid, impt.id()));
-            }
-        }
-    }
-
-    // inline empty wasi functions
-    // for (fid, impt_id) in to_stub {
-    //     let ty = module.types.get(module.funcs.get(fid).ty());
-    //     let params = ty.params().iter().map(|v| v.clone()).collect::<Vec<walrus::ValType>>();
-    //     let results = ty.results().iter().map(|v| v.clone()).collect::<Vec<walrus::ValType>>();
-    //     let mut stub_func = FunctionBuilder::new(&mut module.types, params.as_slice(), results.as_slice());
-    //     stub_func.func_body().unreachable();
-    //     let local_func = stub_func.local_func(vec![]);
-
-    //     let mut func = module.funcs.get_mut(fid);
-    //     func.kind = FunctionKind::Local(local_func);
-
-    //     module.imports.delete(impt_id);
-    // }
-
     Ok(module.emit_wasm())
 }
 

--- a/crates/spidermonkey-embedding-splicer/src/stub_wasi.rs
+++ b/crates/spidermonkey-embedding-splicer/src/stub_wasi.rs
@@ -1,0 +1,86 @@
+use anyhow::{bail, Result};
+
+use walrus::{
+    Function, FunctionBuilder, FunctionKind, ImportKind, ImportedFunction, InstrSeqBuilder,
+    LocalId, Module,
+};
+
+fn stub_import<StubFn>(module: &mut Module, import: &str, name: &str, stub: StubFn) -> Result<()>
+where
+    StubFn: Fn(&mut InstrSeqBuilder) -> Result<Vec<LocalId>>,
+{
+    let Some(iid) = module.imports.find(import, name) else {
+        bail!("Cannot find '{import}#{name}' to stub.");
+    };
+
+    let ImportKind::Function(fid) = module.imports.get(iid).kind else {
+        bail!("'{import}#{name}' is not a function.")
+    };
+
+    let Function {
+        kind: FunctionKind::Import(ImportedFunction { ty, .. }),
+        ..
+    } = module.funcs.get(fid)
+    else {
+        bail!("Can't find type of '{import}#{name}'")
+    };
+
+    let ty = module.types.get(*ty);
+    let (params, results) = (ty.params().to_vec(), ty.results().to_vec());
+
+    let mut builder =
+        FunctionBuilder::new(&mut module.types, params.as_slice(), results.as_slice());
+    let args = stub(&mut builder.func_body())?;
+    let local_func = builder.local_func(args);
+
+    module.funcs.get_mut(fid).kind = FunctionKind::Local(local_func);
+
+    module.imports.delete(iid);
+    Ok(())
+}
+
+fn unreachable_stub(body: &mut InstrSeqBuilder) -> Result<Vec<LocalId>> {
+    body.unreachable();
+    Ok(vec![])
+}
+
+const WASI: &str = "wasi_snapshot_preview1";
+
+pub fn stub_wasi(wasm: Vec<u8>) -> Result<Vec<u8>> {
+    let mut module = Module::from_buffer(wasm.as_slice())?;
+
+    stub_import(&mut module, WASI, "clock_res_get", unreachable_stub)?;
+    stub_import(&mut module, WASI, "environ_get", unreachable_stub)?;
+    stub_import(&mut module, WASI, "environ_sizes_get", unreachable_stub)?;
+    stub_import(&mut module, WASI, "fd_close", unreachable_stub)?;
+    stub_import(&mut module, WASI, "fd_fdstat_set_flags", unreachable_stub)?;
+    stub_import(&mut module, WASI, "fd_prestat_get", unreachable_stub)?;
+    stub_import(&mut module, WASI, "fd_prestat_dir_name", unreachable_stub)?;
+    stub_import(&mut module, WASI, "fd_read", unreachable_stub)?;
+    stub_import(&mut module, WASI, "fd_seek", unreachable_stub)?;
+    stub_import(&mut module, WASI, "path_open", unreachable_stub)?;
+    stub_import(&mut module, WASI, "path_remove_directory", unreachable_stub)?;
+    stub_import(&mut module, WASI, "path_unlink_file", unreachable_stub)?;
+    stub_import(&mut module, WASI, "proc_exit", unreachable_stub)?;
+    stub_import(&mut module, WASI, "random_get", unreachable_stub)?;
+
+    // (func (param i32 i32 i32 i32) (result i32)))
+    stub_import(&mut module, WASI, "clock_time_get", |body| {
+        body.i32_const(0);
+        Ok(vec![])
+    })?;
+
+    // (func (param i32 i32) (result i32)))
+    stub_import(&mut module, WASI, "fd_fdstat_get", |body| {
+        body.i32_const(0);
+        Ok(vec![])
+    })?;
+
+    // (func (param i32 i32 i32 i32) (result i32)))
+    // stub_import(&mut module, WASI, "fd_write", |body| {
+    //     body.local_get(len_local);
+    //     Ok(vec![len_local])
+    // })?;
+
+    Ok(module.emit_wasm())
+}

--- a/crates/spidermonkey-embedding-splicer/wit/spidermonkey-embedding-splicer.wit
+++ b/crates/spidermonkey-embedding-splicer/wit/spidermonkey-embedding-splicer.wit
@@ -24,7 +24,7 @@ world spidermonkey-embedding-splicer {
     imports: list<tuple<string, string, u32>>,
   }
 
-  export stub-wasi: func(engine: list<u8>) -> result<list<u8>, string>
+  export stub-wasi: func(engine: list<u8>, stdout: bool) -> result<list<u8>, string>
 
   export splice-bindings: func(source-name: option<string>, spidermonkey-engine: list<u8>, wit-world: option<string>, wit-path: option<string>, world-name: option<string>) -> result<splice-result, string>
 }

--- a/crates/spidermonkey-embedding-splicer/wit/spidermonkey-embedding-splicer.wit
+++ b/crates/spidermonkey-embedding-splicer/wit/spidermonkey-embedding-splicer.wit
@@ -24,5 +24,7 @@ world spidermonkey-embedding-splicer {
     imports: list<tuple<string, string, u32>>,
   }
 
+  export stub-wasi: func(engine: list<u8>) -> result<list<u8>, string>
+
   export splice-bindings: func(source-name: option<string>, spidermonkey-engine: list<u8>, wit-world: option<string>, wit-path: option<string>, world-name: option<string>) -> result<splice-result, string>
 }

--- a/lib/exports/exports.d.ts
+++ b/lib/exports/exports.d.ts
@@ -1,5 +1,6 @@
 export namespace Exports {
   export function spliceBindings(sourceName: string | null, spidermonkeyEngine: Uint8Array | ArrayBuffer, witWorld: string | null, witPath: string | null, worldName: string | null): SpliceResult;
+  export function stubWasi(engine: Uint8Array | ArrayBuffer): Uint8Array;
 }
 /**
  * # Variants

--- a/lib/spidermonkey-embedding-splicer.d.ts
+++ b/lib/spidermonkey-embedding-splicer.d.ts
@@ -34,4 +34,5 @@ import { ImportsWallClock } from './imports/wall-clock';
 import { ImportsFilesystem } from './imports/filesystem';
 import { ImportsStreams } from './imports/streams';
 import { ImportsRandom } from './imports/random';
+export function stubWasi(engine: Uint8Array | ArrayBuffer): Uint8Array;
 export function spliceBindings(sourceName: string | null, spidermonkeyEngine: Uint8Array | ArrayBuffer, witWorld: string | null, witPath: string | null, worldName: string | null): SpliceResult;

--- a/lib/spidermonkey-embedding-splicer.d.ts
+++ b/lib/spidermonkey-embedding-splicer.d.ts
@@ -34,5 +34,5 @@ import { ImportsWallClock } from './imports/wall-clock';
 import { ImportsFilesystem } from './imports/filesystem';
 import { ImportsStreams } from './imports/streams';
 import { ImportsRandom } from './imports/random';
-export function stubWasi(engine: Uint8Array | ArrayBuffer): Uint8Array;
+export function stubWasi(engine: Uint8Array | ArrayBuffer, stdout: boolean): Uint8Array;
 export function spliceBindings(sourceName: string | null, spidermonkeyEngine: Uint8Array | ArrayBuffer, witWorld: string | null, witPath: string | null, worldName: string | null): SpliceResult;

--- a/lib/spidermonkey-embedding-splicer.js
+++ b/lib/spidermonkey-embedding-splicer.js
@@ -2282,6 +2282,47 @@ function lowering23(arg0, arg1, arg2, arg3) {
 let exports3;
 let realloc1;
 let postReturn0;
+let postReturn1;
+
+function stubWasi(arg0) {
+  const val0 = arg0;
+  const len0 = val0.byteLength;
+  const ptr0 = realloc1(0, 0, 1, len0 * 1);
+  const src0 = new Uint8Array(val0.buffer || val0, val0.byteOffset, len0 * 1);
+  (new Uint8Array(memory0.buffer, ptr0, len0 * 1)).set(src0);
+  const ret = exports1['stub-wasi'](ptr0, len0);
+  let variant3;
+  switch (dataView(memory0).getUint8(ret + 0, true)) {
+    case 0: {
+      const ptr1 = dataView(memory0).getInt32(ret + 4, true);
+      const len1 = dataView(memory0).getInt32(ret + 8, true);
+      const result1 = new Uint8Array(memory0.buffer.slice(ptr1, ptr1 + len1 * 1));
+      variant3= {
+        tag: 'ok',
+        val: result1
+      };
+      break;
+    }
+    case 1: {
+      const ptr2 = dataView(memory0).getInt32(ret + 4, true);
+      const len2 = dataView(memory0).getInt32(ret + 8, true);
+      const result2 = utf8Decoder.decode(new Uint8Array(memory0.buffer, ptr2, len2));
+      variant3= {
+        tag: 'err',
+        val: result2
+      };
+      break;
+    }
+    default: {
+      throw new TypeError('invalid variant discriminant for expected');
+    }
+  }
+  postReturn0(ret);
+  if (variant3.tag === 'err') {
+    throw new ComponentError(variant3.val);
+  }
+  return variant3.val;
+}
 
 function spliceBindings(arg0, arg1, arg2, arg3, arg4) {
   const variant1 = arg0;
@@ -2498,7 +2539,7 @@ function spliceBindings(arg0, arg1, arg2, arg3, arg4) {
       throw new TypeError('invalid variant discriminant for expected');
     }
   }
-  postReturn0(ret);
+  postReturn1(ret);
   if (variant26.tag === 'err') {
     throw new ComponentError(variant26.val);
   }
@@ -2616,9 +2657,10 @@ const $init = (async() => {
     },
   }));
   realloc1 = exports1.cabi_realloc;
-  postReturn0 = exports1['cabi_post_splice-bindings'];
+  postReturn0 = exports1['cabi_post_stub-wasi'];
+  postReturn1 = exports1['cabi_post_splice-bindings'];
 })();
 
 await $init;
 
-export { spliceBindings }
+export { spliceBindings, stubWasi }

--- a/lib/spidermonkey-embedding-splicer.js
+++ b/lib/spidermonkey-embedding-splicer.js
@@ -2284,13 +2284,13 @@ let realloc1;
 let postReturn0;
 let postReturn1;
 
-function stubWasi(arg0) {
+function stubWasi(arg0, arg1) {
   const val0 = arg0;
   const len0 = val0.byteLength;
   const ptr0 = realloc1(0, 0, 1, len0 * 1);
   const src0 = new Uint8Array(val0.buffer || val0, val0.byteOffset, len0 * 1);
   (new Uint8Array(memory0.buffer, ptr0, len0 * 1)).set(src0);
-  const ret = exports1['stub-wasi'](ptr0, len0);
+  const ret = exports1['stub-wasi'](ptr0, len0, arg1 ? 1 : 0);
   let variant3;
   switch (dataView(memory0).getUint8(ret + 0, true)) {
     case 0: {

--- a/src/componentize.js
+++ b/src/componentize.js
@@ -26,6 +26,7 @@ export async function componentize(
     preview2Adapter = preview1AdapterReactorPath(),
     witPath,
     worldName,
+    enableStdout = false,
   } = opts || {};
 
   let { wasm, jsBindings, importWrappers, exports, imports } = spliceBindings(
@@ -48,8 +49,6 @@ export async function componentize(
 
   const input = join(tmpdir(), 'in.wasm');
   const output = join(tmpdir(), 'out.wasm');
-
-  await writeFile('tmpa.wasm', Buffer.from(wasm));
 
   await writeFile(input, Buffer.from(wasm));
 
@@ -311,9 +310,7 @@ export async function componentize(
   }
 
   // after wizering, stub out the wasi imports
-  const finalBin = stubWasi(bin);
-
-  await writeFile('tmpb.wasm', Buffer.from(finalBin));
+  const finalBin = stubWasi(bin, enableStdout);
 
   const component = await metadataAdd(
     await componentNew(

--- a/src/componentize.js
+++ b/src/componentize.js
@@ -125,11 +125,11 @@ export async function componentize(
     process.exit(1);
   }
 
+  const bin = await readFile(output);
+
   const unlinkPromises = Promise.all([unlink(input), unlink(output)]).catch(
     () => {}
   );
-
-  const bin = await readFile(output)
 
   // Check for initialization errors
   // By actually executing the binary in a mini sandbox to get back

--- a/src/componentize.js
+++ b/src/componentize.js
@@ -4,9 +4,8 @@ import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { resolve, join } from "node:path";
 import { readFile, unlink, writeFile } from "node:fs/promises";
-import { spliceBindings } from "../lib/spidermonkey-embedding-splicer.js";
+import { spliceBindings, stubWasi } from "../lib/spidermonkey-embedding-splicer.js";
 import { fileURLToPath } from "node:url";
-import { writeFileSync } from 'node:fs';
 const { version } = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'));
 
 export async function componentize(
@@ -20,13 +19,13 @@ export async function componentize(
   }
   const {
     debug = false,
-    sourceName = "source.js",
+    sourceName = 'source.js',
     engine = fileURLToPath(
-      new URL("../lib/spidermonkey_embedding.wasm", import.meta.url)
+      new URL('../lib/spidermonkey_embedding.wasm', import.meta.url)
     ),
     preview2Adapter = preview1AdapterReactorPath(),
     witPath,
-    worldName
+    worldName,
   } = opts || {};
 
   let { wasm, jsBindings, importWrappers, exports, imports } = spliceBindings(
@@ -47,8 +46,10 @@ export async function componentize(
     console.log(exports);
   }
 
-  const input = join(tmpdir(), "in.wasm");
-  const output = join(tmpdir(), "out.wasm");
+  const input = join(tmpdir(), 'in.wasm');
+  const output = join(tmpdir(), 'out.wasm');
+
+  await writeFile('tmpa.wasm', Buffer.from(wasm));
 
   await writeFile(input, Buffer.from(wasm));
 
@@ -61,19 +62,22 @@ export async function componentize(
     SOURCE_LEN: new TextEncoder().encode(jsSource).byteLength.toString(),
     BINDINGS_LEN: new TextEncoder().encode(jsBindings).byteLength.toString(),
     IMPORT_WRAPPER_CNT: Object.keys(importWrappers).length.toString(),
-    EXPORT_CNT: exports.length.toString()
+    EXPORT_CNT: exports.length.toString(),
   };
 
   for (const [idx, [export_name, expt]] of exports.entries()) {
     env[`EXPORT${idx}_NAME`] = export_name;
-    env[`EXPORT${idx}_ARGS`] = (expt.paramptr ? '*' : '') + expt.params.join(',');
+    env[`EXPORT${idx}_ARGS`] =
+      (expt.paramptr ? '*' : '') + expt.params.join(',');
     env[`EXPORT${idx}_RET`] = (expt.retptr ? '*' : '') + (expt.ret || '');
     env[`EXPORT${idx}_RETSIZE`] = String(expt.retsize);
   }
 
   for (const [idx, [name, importWrapper]] of importWrappers.entries()) {
     env[`IMPORT_WRAPPER${idx}_NAME`] = name;
-    env[`IMPORT_WRAPPER${idx}_LEN`] = new TextEncoder().encode(importWrapper).byteLength.toString();
+    env[`IMPORT_WRAPPER${idx}_LEN`] = new TextEncoder()
+      .encode(importWrapper)
+      .byteLength.toString();
     wizerInput += importWrapper;
   }
 
@@ -92,10 +96,10 @@ export async function componentize(
     let wizerProcess = spawnSync(
       wizer,
       [
-        "--allow-wasi",
+        '--allow-wasi',
         `--dir=.`,
         `--wasm-bulk-memory=true`,
-        "--inherit-env=true",
+        '--inherit-env=true',
         `-o=${output}`,
         input,
       ],
@@ -104,11 +108,11 @@ export async function componentize(
         env,
         input: wizerInput,
         shell: true,
-        encoding: "utf-8",
+        encoding: 'utf-8',
       }
     );
     if (wizerProcess.status !== 0)
-      throw new Error("Wizering failed to complete");
+      throw new Error('Wizering failed to complete');
   } catch (error) {
     console.error(
       `Error: Failed to initialize the compiled Wasm binary with Wizer:\n`,
@@ -122,11 +126,11 @@ export async function componentize(
     process.exit(1);
   }
 
-  const bin = await readFile(output);
-
   const unlinkPromises = Promise.all([unlink(input), unlink(output)]).catch(
     () => {}
   );
+
+  const bin = await readFile(output)
 
   // Check for initialization errors
   // By actually executing the binary in a mini sandbox to get back
@@ -145,7 +149,7 @@ export async function componentize(
       );
     };
 
-    let stderr = "";
+    let stderr = '';
     const module = await WebAssembly.compile(bin);
 
     const mockImports = {
@@ -168,22 +172,22 @@ export async function componentize(
           mem.setUint32(nwritten, written, true);
           return 1;
         },
-        environ_get: eep("environ_get"),
-        environ_sizes_get: eep("environ_sizes_get"),
-        clock_res_get: eep("clock_res_get"),
-        clock_time_get: eep("clock_time_get"),
-        fd_close: eep("fd_close"),
-        fd_fdstat_get: eep("fd_fdstat_get"),
-        fd_fdstat_set_flags: eep("fd_fdstat_set_flags"),
-        fd_prestat_get: eep("fd_prestat_get"),
-        fd_prestat_dir_name: eep("fd_prestat_dir_name"),
-        fd_read: eep("fd_read"),
-        fd_seek: eep("fd_seek"),
-        path_open: eep("path_open"),
-        path_remove_directory: eep("path_remove_directory"),
-        path_unlink_file: eep("path_unlink_file"),
-        proc_exit: eep("proc_exit"),
-        random_get: eep("random_get"),
+        environ_get: eep('environ_get'),
+        environ_sizes_get: eep('environ_sizes_get'),
+        clock_res_get: eep('clock_res_get'),
+        clock_time_get: eep('clock_time_get'),
+        fd_close: eep('fd_close'),
+        fd_fdstat_get: eep('fd_fdstat_get'),
+        fd_fdstat_set_flags: eep('fd_fdstat_set_flags'),
+        fd_prestat_get: eep('fd_prestat_get'),
+        fd_prestat_dir_name: eep('fd_prestat_dir_name'),
+        fd_read: eep('fd_read'),
+        fd_seek: eep('fd_seek'),
+        path_open: eep('path_open'),
+        path_remove_directory: eep('path_remove_directory'),
+        path_unlink_file: eep('path_unlink_file'),
+        proc_exit: eep('proc_exit'),
+        random_get: eep('random_get'),
       },
     };
 
@@ -287,8 +291,14 @@ export async function componentize(
   }
 
   // in debug mode, log the generated bindings for bindings errors
-  if (debug && (status === INIT_BINDINGS_COMPILE || status === INIT_MEM_BINDINGS)) {
-    err += `\n\nGenerated bindings:\n_____\n${jsBindings.split('\n').map((ln, idx) => `${(idx + 1).toString().padStart(4, ' ')} | ${ln}`).join('\n')}\n-----\n`;
+  if (
+    debug &&
+    (status === INIT_BINDINGS_COMPILE || status === INIT_MEM_BINDINGS)
+  ) {
+    err += `\n\nGenerated bindings:\n_____\n${jsBindings
+      .split('\n')
+      .map((ln, idx) => `${(idx + 1).toString().padStart(4, ' ')} | ${ln}`)
+      .join('\n')}\n-----\n`;
   }
 
   if (err) {
@@ -300,15 +310,27 @@ export async function componentize(
     process.exit(1);
   }
 
-  const component = await metadataAdd(await componentNew(bin, Object.entries({
-    wasi_snapshot_preview1: await readFile(preview2Adapter)
-  }), false), Object.entries({
-    language: [['JavaScript', '']],
-    'processed-by': [['ComponentizeJS', version]],
-  }));
+  // after wizering, stub out the wasi imports
+  const finalBin = stubWasi(bin);
+
+  await writeFile('tmpb.wasm', Buffer.from(finalBin));
+
+  const component = await metadataAdd(
+    await componentNew(
+      finalBin,
+      Object.entries({
+        wasi_snapshot_preview1: await readFile(preview2Adapter),
+      }),
+      false
+    ),
+    Object.entries({
+      language: [['JavaScript', '']],
+      'processed-by': [['ComponentizeJS', version]],
+    })
+  );
 
   return {
     component,
-    imports: imports.map(([specifier, impt]) => specifier === '$root' ? [impt, 'default'] : [specifier, impt])
+    imports,
   };
 }

--- a/test/test.js
+++ b/test/test.js
@@ -22,6 +22,7 @@ suite('Builtins', () => {
         }
       `, {
         sourceName: `${name}.js`,
+        enableStdout: true,
       });
     
       const { files } = await transpile(component, { name, wasiShim: true });


### PR DESCRIPTION
This stubs out the unused WASI APIs used in Spidermonkey as they are mostly unused.

By default, this disables `console.log` from printing to stdout, with a new option, `enableStdout: bool` to reenable logging which then brings back in the WASI dependence. In future this should be using wasi logging directly.