### PR TITLE
add support for WIT versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bytecodealliance/componentize-js",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bytecodealliance/componentize-js",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "workspaces": [
         "."
       ],

--- a/test/cases/versions/hello@1.0.0.js
+++ b/test/cases/versions/hello@1.0.0.js
@@ -1,0 +1,3 @@
+export function hello(name) {
+    return `Hello 1.0.0, ${name}`
+}

--- a/test/cases/versions/hello@2.0.0.js
+++ b/test/cases/versions/hello@2.0.0.js
@@ -1,0 +1,7 @@
+export function hello(name) {
+    if (name) {
+        return `Hello 2.0.0, ${name}`
+    } else {
+        return undefined
+    }
+}

--- a/test/cases/versions/source.js
+++ b/test/cases/versions/source.js
@@ -1,0 +1,14 @@
+import { hello as hello1 } from "local:hello/hello@1.0.0"
+import { hello as hello2 } from "local:hello/hello@2.0.0"
+
+export const hello_1_0_0 = {
+    hello: function(name) {
+        return hello1(name)
+    }
+}
+
+export const hello_2_0_0 = {
+    hello: function(name) {
+        return hello2(name)
+    }
+}

--- a/test/cases/versions/test.js
+++ b/test/cases/versions/test.js
@@ -1,0 +1,7 @@
+import { strictEqual } from 'node:assert';
+
+export function test (instance) {
+    strictEqual(instance['local:hello/hello@1.0.0'].hello("foo"), "Hello 1.0.0, foo");
+    strictEqual(instance['local:hello/hello@2.0.0'].hello("bar"), "Hello 2.0.0, bar");
+    strictEqual(instance['local:hello/hello@2.0.0'].hello(undefined), undefined);
+}

--- a/test/cases/versions/wit/deps/hello-1.0.0/hello.wit
+++ b/test/cases/versions/wit/deps/hello-1.0.0/hello.wit
@@ -1,0 +1,5 @@
+package local:hello@1.0.0
+
+interface hello {
+  hello: func(name: string) -> string
+}

--- a/test/cases/versions/wit/deps/hello-2.0.0/hello.wit
+++ b/test/cases/versions/wit/deps/hello-2.0.0/hello.wit
@@ -1,0 +1,5 @@
+package local:hello@2.0.0
+
+interface hello {
+  hello: func(name: option<string>) -> option<string>
+}

--- a/test/cases/versions/wit/world.wit
+++ b/test/cases/versions/wit/world.wit
@@ -1,0 +1,8 @@
+package test:test
+
+world hello {
+  import local:hello/hello@1.0.0
+  export local:hello/hello@1.0.0
+  import local:hello/hello@2.0.0
+  export local:hello/hello@2.0.0
+}


### PR DESCRIPTION
This adds support for importing and exporting versioned interfaces, including multiple versions of the "same" interface (where "same" means "has the same identifier, modulo version").

Note that we currently include the version number in JS identifiers unconditionally.  A future refinement would be to notice when only one version of a given interface is imported or exported and omit the version in that case.

Fixes #60