### PR TITLE
Fix: Floats Handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,7 +195,7 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 [[package]]
 name = "js-component-bindgen"
 version = "0.11.0"
-source = "git+https://github.com/bytecodealliance/jco?branch=toolchain-upgrade#be4ab7c89f99776330b6cb5c28eb39a5bff4928f"
+source = "git+https://github.com/bytecodealliance/jco?branch=main#b85f6bc6821587906a38d4fba7a0901ffff37af4"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ base64 = "0.21.2"
 bitflags = "1.3.2"
 env_logger = "0.10.0"
 heck =  { version = "0.4", features = ["unicode"] }
-js-component-bindgen = { git = "https://github.com/bytecodealliance/jco", branch = "toolchain-upgrade", no-default-features = ["transpile-bindgen"] }
+js-component-bindgen = { git = "https://github.com/bytecodealliance/jco", branch = "main", no-default-features = ["transpile-bindgen"] }
 pulldown-cmark = { version = "0.8", default-features = false }
 walrus = "0.20.1"
 wasm-encoder = "0.33.1"

--- a/spidermonkey_embedding/spidermonkey_embedding.cpp
+++ b/spidermonkey_embedding/spidermonkey_embedding.cpp
@@ -951,8 +951,6 @@ __attribute__((export_name("call"))) uint32_t call(uint32_t fn_idx, void *argptr
       }
       break;
     case CoreVal::F32:
-      // TODO: lower these checks into the splicing Wasm generation itself so that these are direct floats and doubles
-      //       (like we do for arguments)
       *((float *)retptr) = (r.asRawBits() >> 32) == 0xFFFFFF81 ? static_cast<float>(r.toInt32()) : static_cast<float>(r.toDouble());
       break;
     case CoreVal::F64:

--- a/spidermonkey_embedding/spidermonkey_embedding.cpp
+++ b/spidermonkey_embedding/spidermonkey_embedding.cpp
@@ -951,10 +951,12 @@ __attribute__((export_name("call"))) uint32_t call(uint32_t fn_idx, void *argptr
       }
       break;
     case CoreVal::F32:
-      *((float *)retptr) = static_cast<float>(r.toDouble());
+      // TODO: lower these checks into the splicing Wasm generation itself so that these are direct floats and doubles
+      //       (like we do for arguments)
+      *((float *)retptr) = (r.asRawBits() >> 32) == 0xFFFFFF81 ? static_cast<float>(r.toInt32()) : static_cast<float>(r.toDouble());
       break;
     case CoreVal::F64:
-      *((double *)retptr) = r.toDouble();
+      *((double *)retptr) = (r.asRawBits() >> 32) == 0xFFFFFF81 ? static_cast<double>(r.toInt32()) : r.toDouble();
       break;
     }
   }

--- a/spidermonkey_embedding/spidermonkey_embedding.cpp
+++ b/spidermonkey_embedding/spidermonkey_embedding.cpp
@@ -951,10 +951,10 @@ __attribute__((export_name("call"))) uint32_t call(uint32_t fn_idx, void *argptr
       }
       break;
     case CoreVal::F32:
-      *((float *)retptr) = (r.asRawBits() >> 32) == 0xFFFFFF81 ? static_cast<float>(r.toInt32()) : static_cast<float>(r.toDouble());
+      *((float *)retptr) = r.isInt32() ? static_cast<float>(r.toInt32()) : static_cast<float>(r.toDouble());
       break;
     case CoreVal::F64:
-      *((double *)retptr) = (r.asRawBits() >> 32) == 0xFFFFFF81 ? static_cast<double>(r.toInt32()) : r.toDouble();
+      *((double *)retptr) = r.isInt32() ? static_cast<double>(r.toInt32()) : r.toDouble();
       break;
     }
   }

--- a/test/cases/floats/floats.js
+++ b/test/cases/floats/floats.js
@@ -19,3 +19,7 @@ export function float64Result () {
 export function float64Result2 () {
   return 3;
 }
+
+export function float32Result2 () {
+  return 3;
+}

--- a/test/cases/floats/floats.js
+++ b/test/cases/floats/floats.js
@@ -15,3 +15,7 @@ export function float32Result () {
 export function float64Result () {
   return float64;
 }
+
+export function float64Result2 () {
+  return 3;
+}

--- a/test/cases/floats/source.js
+++ b/test/cases/floats/source.js
@@ -2,9 +2,13 @@ import { float32Param, float64Param, float32Result, float64Result } from 'local:
 
 export const floats = {
   float32Param (x) {
+    if (x === 3)
+      return float32Param(3);
     return float32Param(x);
   },
   float64Param (x) {
+    if (x === 3)
+      return float64Param(3);
     return float64Param(x);
   },
   float32Result () {
@@ -14,6 +18,9 @@ export const floats = {
     return float64Result();
   },
   float64Result2 () {
+    return 3;
+  },
+  float32Result2 () {
     return 3;
   },
 };

--- a/test/cases/floats/source.js
+++ b/test/cases/floats/source.js
@@ -13,4 +13,7 @@ export const floats = {
   float64Result () {
     return float64Result();
   },
+  float64Result2 () {
+    return 3;
+  },
 };

--- a/test/cases/floats/test.js
+++ b/test/cases/floats/test.js
@@ -5,4 +5,5 @@ export function test (instance) {
   strictEqual(instance.floats.float64Param(1.51111111111111), undefined);
   strictEqual(instance.floats.float32Result(), 1.5);
   strictEqual(instance.floats.float64Result(), 1.51111111111111);
+  strictEqual(instance.floats.float64Result2(), 3);
 }

--- a/test/cases/floats/test.js
+++ b/test/cases/floats/test.js
@@ -5,5 +5,10 @@ export function test (instance) {
   strictEqual(instance.floats.float64Param(1.51111111111111), undefined);
   strictEqual(instance.floats.float32Result(), 1.5);
   strictEqual(instance.floats.float64Result(), 1.51111111111111);
+  strictEqual(instance.floats.float32Param(3), undefined);
+  strictEqual(instance.floats.float64Param(3), undefined);
+  strictEqual(instance.floats.float32Result(), 3);
+  strictEqual(instance.floats.float64Result(), 3);
   strictEqual(instance.floats.float64Result2(), 3);
+  strictEqual(instance.floats.float32Result2(), 3);
 }

--- a/test/cases/floats/world.wit
+++ b/test/cases/floats/world.wit
@@ -6,6 +6,7 @@ interface floats {
   float32-result: func() -> float32
   float64-result: func() -> float64
   float64-result2: func() -> float64
+  float32-result2: func() -> float32
 }
 
 world the-world {

--- a/test/cases/floats/world.wit
+++ b/test/cases/floats/world.wit
@@ -5,6 +5,7 @@ interface floats {
   float64-param: func(x: float64)
   float32-result: func() -> float32
   float64-result: func() -> float64
+  float64-result2: func() -> float64
 }
 
 world the-world {


### PR DESCRIPTION
Fixes https://github.com/bytecodealliance/componentize-js/issues/63.

Spidermonkey stores integer literals as integers, which we need to carefully detect when doing value parsing. This updates the float handling to detect the integer case properly and branch on the float conversion appropriately.

This affects both passed parameters and return values.