### PR TITLE
support destructors for imported resources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,8 +172,7 @@ checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 [[package]]
 name = "js-component-bindgen"
 version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17d196a847c0c695c96f5f804b19253cb544e57b7f81b01ecd0574e3523e346d"
+source = "git+https://github.com/bytecodealliance/jco#b8f32cf3f24e28f643da23e96766c74d88f638f6"
 dependencies = [
  "anyhow",
  "base64",
@@ -620,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ace9943d89bbf3dbbc71b966da0e7302057b311f36a4ac3d65ddfef17b52cf"
+checksum = "43771ee863a16ec4ecf9da0fc65c3bbd4a1235c8e3da5f094b562894843dfa76"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ base64 = "0.21.2"
 bitflags = "1.3.2"
 env_logger = "0.10.0"
 heck =  { version = "0.4", features = ["unicode"] }
-js-component-bindgen = { version = "0.13.2", no-default-features = ["transpile-bindgen"] }
+# TODO: switch this back to a release once https://github.com/bytecodealliance/jco/pull/237 has been released
+js-component-bindgen = { git = "https://github.com/bytecodealliance/jco", no-default-features = ["transpile-bindgen"] }
 pulldown-cmark = { version = "0.8", default-features = false }
 walrus = "0.20.1"
 wasm-encoder = "0.35.0"
@@ -26,4 +27,4 @@ wat = "1.0.77"
 wit-bindgen = { version = "0.13.0" }
 wit-bindgen-core = { version = "0.13.0" }
 wit-component = { version = "0.16", features = ["dummy-module"] }
-wit-parser = "0.12.1"
+wit-parser = "0.12.2"

--- a/test/cases/resource-borrow-import/source.js
+++ b/test/cases/resource-borrow-import/source.js
@@ -1,5 +1,17 @@
 import { Thing, foo } from "test:test/resource-borrow-import"
 
+const disposeSymbol = Symbol.dispose || Symbol.for('dispose')
+
 export function test(value) {
     return foo(new Thing(value + 1)) + 4
+}
+
+export function testBorrow(value) {
+    return foo(value) + 6
+}
+
+export function testBorrowEarlyDrop(value) {
+    const result = foo(value) + 8
+    value[disposeSymbol]()
+    return result
 }

--- a/test/cases/resource-borrow-import/test.js
+++ b/test/cases/resource-borrow-import/test.js
@@ -1,5 +1,10 @@
 import { strictEqual } from 'node:assert'
+import { Thing } from "./resource-borrow-import.js"
 
 export function test(instance) {
     strictEqual(instance.test(42), 42 + 1 + 2 + 3 + 4)
+    
+    let thing = new Thing(42)
+    strictEqual(instance.testBorrow(thing), 42 + 2 + 3 + 6)
+    strictEqual(instance.testBorrowEarlyDrop(thing), 42 + 2 + 3 + 8)
 }

--- a/test/cases/resource-borrow-import/world.wit
+++ b/test/cases/resource-borrow-import/world.wit
@@ -9,7 +9,11 @@ interface resource-borrow-import {
 }
 
 world test {
+  use resource-borrow-import.{thing}
+
   import resource-borrow-import
 
   export test: func(v: u32) -> u32
+  export test-borrow: func(v: borrow<thing>) -> u32
+  export test-borrow-early-drop: func(v: borrow<thing>) -> u32
 }


### PR DESCRIPTION
This provides partial support for #68.  I've focused on imported resources to begin with since APIs such as `wasi:http` make heavy use of child handles, which must be disposed in the correct order to avoid traps.

Supporting destructors for exported resources may also be useful, but not as urgent with respect to WASI.